### PR TITLE
Add Docker support with travis build closes #6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 install:
 - make
 script: |
-  export IMAGE_NAME=gableroux/gothub
+  export IMAGE_NAME=itchio/gothub
   docker build -f Dockerfile -t $IMAGE_NAME:$COMMIT .
   docker login -u $REGISTRY_USER -p $REGISTRY_PASS
   docker push "${IMAGE_NAME}:${COMMIT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+sudo: required
+services:
+- docker
+before_install:
+- docker pull golang:alpine
+install:
+- make
+script: |
+  export IMAGE_NAME=gableroux/gothub
+  docker build -f Dockerfile -t $IMAGE_NAME:$COMMIT .
+  docker login -u $REGISTRY_USER -p $REGISTRY_PASS
+  docker push "${IMAGE_NAME}:${COMMIT}"
+  if [ "$TRAVIS_BRANCH" == "master" ]; then
+    docker tag $IMAGE_NAME:$COMMIT $IMAGE_NAME:latest
+    docker push "${IMAGE_NAME}:latest"
+  fi
+env:
+  global:
+  - COMMIT=${TRAVIS_COMMIT::8}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine as builder
+
+RUN apk update && \
+    apk upgrade && \
+    apk add -u git && \
+    go get github.com/itchio/gothub
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates jq
+
+COPY --from=builder /go/bin/gothub /bin/gothub
+
+CMD ["gothub"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/itchio/gothub.svg?branch=master)](https://travis-ci.org/itchio/gothub)
+
 gothub
 ======
 


### PR DESCRIPTION
Same as #11 but slightly different. sks's provided links to build didn't seem to work (maybe something to do with [recent migration from travis](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps)?)

Anyway, here's quite similar PR confirmed working. Instructions to get it working:

```bash
travis init
```

Then visit travis and add these two env variables:

* `REPOSITORY_USER`
* `REPOSITORY_PASS`

Example build:
https://travis-ci.com/GabLeRoux/github-release/builds/72990504

Built image on docker:
https://hub.docker.com/r/gableroux/gothub/

Docker image usage example:

```bash
docker run -it --rm gableroux/gothub gothub -h
```
_replace image name with `itchio/gothub`_.

All credits go to @sks :+1:

Resolves #6 :v: